### PR TITLE
Fix: Correct typewriter scrolling in tables

### DIFF
--- a/main.js
+++ b/main.js
@@ -147,7 +147,7 @@ module.exports = class ScrollerPlugin extends Plugin {
 			onWheel(event) {
                 const targetElement = event.target;
                 if (targetElement && typeof targetElement.closest === 'function') {
-                    if (targetElement.closest('table, tr, td, th')) {
+                    if (targetElement.closest('table, tr, td, th, .bases-view, .bases-embed')) {
                         return; 
                     }
                 }

--- a/main.js
+++ b/main.js
@@ -145,29 +145,29 @@ module.exports = class ScrollerPlugin extends Plugin {
             }
 			
 			onWheel(event) {
-                const targetElement = event.target;
-                if (targetElement && typeof targetElement.closest === 'function') {
-                    if (targetElement.closest('table, tr, td, th, .bases-view, .bases-embed')) {
-                        return; 
-                    }
-                }
-                
-                if (!plugin.settings.enableCursorScrolling || !this.shouldApplyTypewriterFeatures()) {
-                    return;
-                }
+					const targetElement = event.target;
+					if (targetElement && typeof targetElement.closest === 'function') {
+						if (targetElement.closest('table, tr, td, th, .bases-view, .bases-embed, .metadata-container, .image-embed, .internal-embed')) {
+							return; 
+						}
+					}
+					
+					if (!plugin.settings.enableCursorScrolling || !this.shouldApplyTypewriterFeatures()) {
+						return;
+					}
 
-                event.preventDefault();
+					event.preventDefault();
 
-                this.wheelAccumulator += event.deltaY;
-                const sensitivity = plugin.settings.cursorScrollingSensitivity;
+					this.wheelAccumulator += event.deltaY;
+					const sensitivity = plugin.settings.cursorScrollingSensitivity;
 
-                if (Math.abs(this.wheelAccumulator) >= sensitivity) {
-                    const command = this.wheelAccumulator > 0 ? cursorLineDown : cursorLineUp;
-                    command(this.view);                   
-                    this.wheelAccumulator = 0;
-                }
-            }
-
+					if (Math.abs(this.wheelAccumulator) >= sensitivity) {
+						const command = this.wheelAccumulator > 0 ? cursorLineDown : cursorLineUp;
+						command(this.view);                   
+						this.wheelAccumulator = 0;
+					}
+			}
+			
             scheduleScrollUpdate() {
                 if (this.pendingScrollUpdate) return;
                 this.pendingScrollUpdate = true;
@@ -193,6 +193,14 @@ module.exports = class ScrollerPlugin extends Plugin {
                 
                 if (!containerRect) return;
 
+                const cursorHead = editorView.state.selection.main.head;
+                if (cursorHead === 0) {
+                    if (Math.abs(scrollContainer.scrollTop) > 2) {
+                         scrollContainer.scrollTop = 0;
+                    }
+                    return;
+                }
+
                 const verticalOffset = editorView.dom.clientHeight * plugin.settings.typewriterOffset;
                 const currentTop = scrollContainer.scrollTop;
 
@@ -212,8 +220,8 @@ module.exports = class ScrollerPlugin extends Plugin {
 
                     } else {
                         
-                        const cursorPosition = editorView.state.selection.main.head;
-                        const cmCoords = editorView.coordsAtPos(cursorPosition);
+                        // We already grabbed cursorHead above
+                        const cmCoords = editorView.coordsAtPos(cursorHead);
                         if (!cmCoords) return;
                         cursorViewportTop = cmCoords.top;
                     }


### PR DESCRIPTION
The goal was to implement "typewriter scrolling" within tables for the Obsidian Scroller Plugin, which was not functional with the previous version of the plug-in. The core issue was a conflict between the Obsidian editor's two methods for determining cursor position:

- CodeMirror's Native API (coordsAtPos): Works perfectly for standard text lines but returns inaccurate coordinates (the cell's top edge, not the cursor's line) when inside a Markdown table, causing the view to jump.
- Browser's Native API (window.getSelection): Required for accurate coordinates inside tables, but introduced new bugs (like jumping to the top of the table) due to inconsistent reporting on the last table row.

How It Works:
- Separated the logic for scrolling normal text vs. table text (via a funtion `isCursorInTable()` that uses the stable `window.getSelection()` API to detect if the cursor is within a <td> or <th> element).
- If the cursor is in a table: execute the `window.getSelection().getBoundingClientRect()` method, which finds the blinking cursor. 
- If the cursor is on a normal line: use `editorView.coordsAtPos()` to determine the proper line.